### PR TITLE
Persist layout widget via game instance

### DIFF
--- a/Source/LabelManager/Private/LabelManagementPlayerController.cpp
+++ b/Source/LabelManager/Private/LabelManagementPlayerController.cpp
@@ -3,7 +3,7 @@
 #include "GameFramework/Pawn.h"
 #include "LabelManagerGameInstance.h"
 #include "Math/RotationMatrix.h"
-#include "UI/Widget_DashboardLayout.h"
+#include "UI/Layout.h"
 #include "Engine/EngineBaseTypes.h"
 
 ALabelManagementPlayerController::ALabelManagementPlayerController()
@@ -18,7 +18,7 @@ void ALabelManagementPlayerController::BeginPlay()
 
     if (ULabelManagerGameInstance* GameInstance = GetGameInstance<ULabelManagerGameInstance>())
     {
-        if (UWidget_DashboardLayout* Layout = GameInstance->EnsureLayoutForPlayer(this))
+        if (ULayout* Layout = GameInstance->EnsureLayoutForPlayer(this))
         {
             FInputModeGameAndUI InputMode;
             InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);

--- a/Source/LabelManager/Private/LabelManagerGameInstance.cpp
+++ b/Source/LabelManager/Private/LabelManagerGameInstance.cpp
@@ -1,12 +1,12 @@
 #include "LabelManagerGameInstance.h"
 
 #include "Blueprint/UserWidget.h"
-#include "UI/Widget_DashboardLayout.h"
+#include "UI/Layout.h"
 #include "GameFramework/PlayerController.h"
 
 ULabelManagerGameInstance::ULabelManagerGameInstance()
 {
-    LayoutGUIClass = UWidget_DashboardLayout::StaticClass();
+    LayoutGUIClass = ULayout::StaticClass();
 }
 
 void ULabelManagerGameInstance::Init()
@@ -15,7 +15,7 @@ void ULabelManagerGameInstance::Init()
 
     if (!LayoutGUI && LayoutGUIClass)
     {
-        LayoutGUI = CreateWidget<UWidget_DashboardLayout>(this, LayoutGUIClass);
+        LayoutGUI = CreateWidget<ULayout>(this, LayoutGUIClass);
         if (LayoutGUI)
         {
             LayoutGUI->AddToViewport(0);
@@ -23,11 +23,11 @@ void ULabelManagerGameInstance::Init()
     }
 }
 
-UWidget_DashboardLayout* ULabelManagerGameInstance::EnsureLayoutForPlayer(APlayerController* OwningPlayer)
+ULayout* ULabelManagerGameInstance::EnsureLayoutForPlayer(APlayerController* OwningPlayer)
 {
     if (!LayoutGUI && LayoutGUIClass)
     {
-        LayoutGUI = CreateWidget<UWidget_DashboardLayout>(this, LayoutGUIClass);
+        LayoutGUI = CreateWidget<ULayout>(this, LayoutGUIClass);
     }
 
     if (!LayoutGUI)

--- a/Source/LabelManager/Private/UI/WidgetLibrary.cpp
+++ b/Source/LabelManager/Private/UI/WidgetLibrary.cpp
@@ -1,44 +1,37 @@
 #include "UI/WidgetLibrary.h"
-#include "UI/Widget_DashboardLayout.h"
-#include "UI/DashboardViewModel.h"
 #include "Blueprint/UserWidget.h"
 #include "LabelManagerGameInstance.h"
+#include "UI/Layout.h"
 #include "Engine/World.h"
 
-UWidget_DashboardLayout* UWidgetLibrary::CreateDashboard(UWorld* World, APlayerController* PC)
+ULayout* UWidgetLibrary::CreateDashboard(UWorld* World, APlayerController* PC)
 {
-    if (!World || !PC)
+    if (!World)
     {
         return nullptr;
     }
 
     if (ULabelManagerGameInstance* GameInstance = World->GetGameInstance<ULabelManagerGameInstance>())
     {
-        if (UWidget_DashboardLayout* Layout = GameInstance->EnsureLayoutForPlayer(PC))
-        {
-            UDashboardViewModel* ViewModel = NewObject<UDashboardViewModel>(World);
-            if (ViewModel)
-            {
-                ViewModel->RefreshAll();
-                Layout->SetViewModel(ViewModel);
-            }
-            return Layout;
-        }
+        return GameInstance->EnsureLayoutForPlayer(PC);
     }
 
-    UDashboardViewModel* ViewModel = NewObject<UDashboardViewModel>(World);
-    if (!ViewModel)
+    APlayerController* TargetPC = PC ? PC : World->GetFirstPlayerController();
+    ULayout* Layout = nullptr;
+
+    if (TargetPC)
     {
-        return nullptr;
+        Layout = CreateWidget<ULayout>(TargetPC, ULayout::StaticClass());
+    }
+    else
+    {
+        Layout = CreateWidget<ULayout>(World, ULayout::StaticClass());
     }
 
-    ViewModel->RefreshAll();
-
-    UWidget_DashboardLayout* Layout = CreateWidget<UWidget_DashboardLayout>(PC, UWidget_DashboardLayout::StaticClass());
     if (Layout)
     {
-        Layout->SetViewModel(ViewModel);
         Layout->AddToViewport();
     }
+
     return Layout;
 }

--- a/Source/LabelManager/Public/LabelManagerGameInstance.h
+++ b/Source/LabelManager/Public/LabelManagerGameInstance.h
@@ -4,7 +4,7 @@
 #include "Engine/GameInstance.h"
 #include "LabelManagerGameInstance.generated.h"
 
-class UWidget_DashboardLayout;
+class ULayout;
 class APlayerController;
 
 /**
@@ -21,18 +21,18 @@ public:
 
     /** Returns the dashboard layout widget if it has been created. */
     UFUNCTION(BlueprintPure, Category = "UI")
-    UWidget_DashboardLayout* GetLayoutWidget() const { return LayoutGUI; }
+    ULayout* GetLayoutWidget() const { return LayoutGUI; }
 
     /** Ensures the layout widget exists, is owned by the supplied player and added to the viewport. */
     UFUNCTION(BlueprintCallable, Category = "UI")
-    UWidget_DashboardLayout* EnsureLayoutForPlayer(APlayerController* OwningPlayer);
+    ULayout* EnsureLayoutForPlayer(APlayerController* OwningPlayer);
 
 protected:
     /** Class used to instantiate the persistent dashboard layout widget. */
     UPROPERTY(EditDefaultsOnly, Category = "UI")
-    TSubclassOf<UWidget_DashboardLayout> LayoutGUIClass;
+    TSubclassOf<ULayout> LayoutGUIClass;
 
     /** Persistent layout widget instance kept alive for the lifetime of the game instance. */
     UPROPERTY()
-    UWidget_DashboardLayout* LayoutGUI = nullptr;
+    ULayout* LayoutGUI = nullptr;
 };

--- a/Source/LabelManager/Public/UI/WidgetLibrary.h
+++ b/Source/LabelManager/Public/UI/WidgetLibrary.h
@@ -3,8 +3,7 @@
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "WidgetLibrary.generated.h"
 
-class UWidget_DashboardLayout;
-class UDashboardViewModel;
+class ULayout;
 class APlayerController;
 
 UCLASS()
@@ -13,5 +12,5 @@ class LABELMANAGER_API UWidgetLibrary : public UBlueprintFunctionLibrary
     GENERATED_BODY()
 public:
     UFUNCTION(BlueprintCallable, Category="LabelUI", meta=(WorldContext="World"))
-    static UWidget_DashboardLayout* CreateDashboard(UWorld* World, APlayerController* PC);
+    static ULayout* CreateDashboard(UWorld* World, APlayerController* PC);
 };

--- a/Source/MusicLabel/DeskActor.cpp
+++ b/Source/MusicLabel/DeskActor.cpp
@@ -4,8 +4,7 @@
 #include "Components/StaticMeshComponent.h"
 #include "Engine/CollisionProfile.h"
 #include "InputCoreTypes.h"
-#include "Blueprint/UserWidget.h"
-#include "Blueprint/WidgetBlueprintLibrary.h"
+#include "LabelManager/Public/LabelManagerGameInstance.h"
 #include "LabelManager/Public/UI/Layout.h"
 
 #define LOCTEXT_NAMESPACE "DeskActor"
@@ -87,12 +86,9 @@ void ADeskActor::HandleDeskClicked(UPrimitiveComponent* TouchedComponent, FKey B
     {
         if (UWorld* World = GetWorld())
         {
-            TArray<UUserWidget*> Widgets;
-            UWidgetBlueprintLibrary::GetAllWidgetsOfClass(World, Widgets, ULayout::StaticClass(), false);
-
-            if (Widgets.Num() > 0)
+            if (ULabelManagerGameInstance* GameInstance = World->GetGameInstance<ULabelManagerGameInstance>())
             {
-                if (ULayout* LayoutWidget = Cast<ULayout>(Widgets[0]))
+                if (ULayout* LayoutWidget = GameInstance->EnsureLayoutForPlayer(World->GetFirstPlayerController()))
                 {
                     LayoutWidget->ShowSignedArtistsWidget();
                 }

--- a/Source/MusicLabel/Subsystems/EventSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/EventSubsystem.cpp
@@ -1,7 +1,6 @@
 #include "EventSubsystem.h"
-#include "Blueprint/WidgetBlueprintLibrary.h"
 #include "Engine/World.h"
-#include "LabelManager/Public/UI/DashboardViewModel.h"
+#include "LabelManager/Public/LabelManagerGameInstance.h"
 #include "LabelManager/Public/UI/Layout.h"
 #include "LabelManager/public/LabelDataAssets.h"
 #include "TimerManager.h"
@@ -11,11 +10,12 @@ void UEventSubsystem::TriggerEvent(const FGameEvent &Event) {
          *Event.Description);
 
   if (!LayoutWidget) {
-    TArray<UUserWidget *> Widgets;
-    UWidgetBlueprintLibrary::GetAllWidgetsOfClass(
-        GetWorld(), Widgets, ULayout::StaticClass(), false);
-    if (Widgets.Num() > 0) {
-      LayoutWidget = Cast<ULayout>(Widgets[0]);
+    if (UWorld *World = GetWorld()) {
+      if (ULabelManagerGameInstance *GameInstance =
+              World->GetGameInstance<ULabelManagerGameInstance>()) {
+        LayoutWidget =
+            GameInstance->EnsureLayoutForPlayer(World->GetFirstPlayerController());
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- keep the `ULayout` dashboard widget alive in `ULabelManagerGameInstance` and expose helpers to reuse it
- update the player controller, desk actor, and event subsystem to fetch the persistent layout from the game instance instead of scanning the viewport
- simplify the widget library to rely on the persistent layout instance and stop creating dashboard view models

## Testing
- not run (unreal project)


------
https://chatgpt.com/codex/tasks/task_e_68d1a9173ec0832e99054068cb1f6393